### PR TITLE
Trim text input to 1000 chars to avoid 400 errors

### DIFF
--- a/src/text-comments/index.js
+++ b/src/text-comments/index.js
@@ -12,7 +12,9 @@ export default class TextCommentsScreen extends Screen {
   }
 
   onSubmit(value) {
-    this.app.onTextSubmit(value);
+    // Trim input to 1000 characters to avoid validation errors
+    const cleanValue = value.substr(0, 1000);
+    this.app.onTextSubmit(cleanValue);
   }
 
   addListeners(node) {

--- a/tests/integration/text-comments.test.js
+++ b/tests/integration/text-comments.test.js
@@ -29,8 +29,19 @@ describe('Text comments', () => {
     expect(helpText).not.toBe(null);
   });
 
-  it.skip('should have max character limit', () => {
-    test.todo('max char limit');
+  it('should trim input at max character limit', async (done) => {
+    const textarea = await page.$('textarea');
+    const submitButton = await page.$('.nhsuk-user-feedback-form--submit');
+    // Type a 1001-char long comment
+    await textarea.type('A'.repeat(1001));
+    page.once('request', (request) => {
+      const data = JSON.parse(request.postData());
+      // comment that actually gets posted should be trimmed to 1000 chars
+      expect(data).toEqual({ comments: 'A'.repeat(1000) });
+      expect(request.url()).toBe('http://localhost:8080/my-endpoint/comments');
+      done();
+    });
+    await submitButton.click();
   });
 
   it('submission should register comments', async (done) => {


### PR DESCRIPTION
The user-feedback-store will not accept comments bigger than 1000 chars. We simply trim down user input silently.
If we find lots of 1000-char-long comments during our trial run, we will think about increasing the char limit or adding a "max 1000 chars" warning.