### PR TITLE
Add the node auth token when authenticating with registry-url setting

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,8 @@ jobs:
         with:
           node-version: 12
           registry-url: https://registry.npmjs.org/
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NODE_AUTH_TOKEN}}
       - run: npm ci
       - run: npm run build:production
       - name: Create Release
@@ -38,5 +40,3 @@ jobs:
           asset_content_type: text/javascript
       - name: Publish npm package
         run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NODE_AUTH_TOKEN}}


### PR DESCRIPTION
I've got this wrong twice now. Had an unauthenticated error in the last action. I think it's because the token needs to be in the env when setting up the node environment, not when running `npm publish`